### PR TITLE
Update archive_folders_to_standby.md

### DIFF
--- a/admin/archive_folders_to_standby.md
+++ b/admin/archive_folders_to_standby.md
@@ -41,12 +41,12 @@ To compress it I can issue the following  commands
 a) use the same project name as part of the compressed file name **AND**
 b) add the date to the compressed file (I’ll use the date I wrote this document in the format YYYYMMDD, or 20201020)
 c) to ensure the compression finished,  add the `—remove-files` option to the tar command, this will remove the files once the compression has scceeded. 
-In general, the command to compress files would then look like this:
-`tar -cvzf --remove-files YYYYMMDD_folder.tar.gz folder`
+In general, the command to compress files would then look like this (`--remove-files` has to be before the other options as `-f` indicates a file name coming after):
+`tar --remove -files-cvzf  YYYYMMDD_folder.tar.gz folder`
 
 
 And in the case of this Arlelen Sharpe hbc038956  example, it would look like this:
-`tar -cvzf  20201020_Sharpe_RNAseq_analysis_of_siRNA_treated_PANCafs_and_myeloid_cells_after_coculture_hbc03895.tar.gz 20201020_Sharpe_RNAseq_analysis_of_siRNA_treated_PANCafs_and_myeloid_cells_after_coculture_hbc03895`
+`tar --remove-files -cvzf  20201020_Sharpe_RNAseq_analysis_of_siRNA_treated_PANCafs_and_myeloid_cells_after_coculture_hbc03895.tar.gz Sharpe_RNAseq_analysis_of_siRNA_treated_PANCafs_and_myeloid_cells_after_coculture_hbc03895`
 This will compress the folder  and remove the original files (which will still be around in the backed up .snapshot folder for some weeks or months!)
 
 ## 5) Login to the transfer node


### PR DESCRIPTION
When using instructions --remove-files option is not correctly placed. `-f` requires a file name after so if written as indicated it will create the --remove-files file instead.
Also, adjusted remove the date from the original folder name as it should not have it in a real case. Date goes with the tar.gz file, not the folder.